### PR TITLE
fix: Ignore changes from unvalidated fields

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -33,8 +33,12 @@ class Form extends Component {
     };
 
     onChange = e => {
+        if (!this.state.config[e.target.name]) {
+            return;
+        }
         const value =
             e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+
         const fields = {
             ...this.state.fields,
             [e.target.name]: value,


### PR DESCRIPTION
This fix makes sure change events from unvalidated fields don't show up in the fields array, and
aren't validated.