### PR TITLE
fix: Improve handling of initial values

### DIFF
--- a/src/Validation.js
+++ b/src/Validation.js
@@ -18,20 +18,22 @@ class Validation extends Component {
         unregister: func,
     };
 
-    getFieldValues = () => {
-        const { config, fields, initialValues } = this.props;
-
+    getFields = source => {
+        const { config } = this.props;
+        const getFirstDefinedValue = (...values) =>
+            values.find(value => value !== undefined);
         return Object.keys(config).reduce(
             (allFields, field) => ({
                 ...allFields,
-                [field]: fields[field] || initialValues[field] || '',
+                [field]: getFirstDefinedValue(source[field], ''),
             }),
             {},
         );
     };
 
     componentDidMount() {
-        this.props.register(this.props.config, this.getFieldValues());
+        const { register, initialValues, config } = this.props;
+        register(config, this.getFields(initialValues));
     }
     componentWillUnmount() {
         this.props.unregister(this.props.config);
@@ -48,7 +50,7 @@ class Validation extends Component {
 
         const childrenArgs = {
             errors,
-            fields: this.getFieldValues(),
+            fields: this.getFields(fields),
             submitted,
             setField,
         };


### PR DESCRIPTION
This commit fixes two bugs. Firstly, it adresses an issue where the initial value of a field would
be shown whenever the user emptied the input. Secondly, this commit lets the user pass in the
boolean false (or other falsy values) as a valid value

Fixes #6