### PR TITLE
feat: Add resetAll to onSubmit arguments

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -85,6 +85,7 @@ class Form extends Component {
             errors,
             fields,
             isValid: Object.values(errors).every(error => error === null),
+            resetAll: this.onReset,
         });
     };
 

--- a/src/__tests__/integration-tests.spec.js
+++ b/src/__tests__/integration-tests.spec.js
@@ -96,6 +96,7 @@ describe('<FormValidation />', () => {
             errors: { username: 'username required', email: 'email required' },
             fields: { username: '', email: '' },
             isValid: false,
+            resetAll: expect.any(Function),
         });
     });
 


### PR DESCRIPTION
This change introduces a `resetAll` argument to the onSubmit handler.
This will let you reset your form after a successful submit, if you
need to for some reason.

Fixes #37 